### PR TITLE
Update some examples for AllenNLP 1.0.0

### DIFF
--- a/examples/generation/lm.ipynb
+++ b/examples/generation/lm.ipynb
@@ -6,7 +6,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install allennlp\n",
+    "!pip install allennlp==1.0.0\n",
+    "!pip install allennlp-models==1.0.0\n",
     "!git clone https://github.com/mhagiwara/realworldnlp.git\n",
     "%cd realworldnlp"
    ]
@@ -24,9 +25,10 @@
     "import torch.optim as optim\n",
     "from allennlp.common.file_utils import cached_path\n",
     "from allennlp.common.util import START_SYMBOL, END_SYMBOL\n",
+    "from allennlp.data import DataLoader, AllennlpDataset\n",
+    "from allennlp.data.samplers import BucketBatchSampler\n",
     "from allennlp.data.fields import TextField\n",
     "from allennlp.data.instance import Instance\n",
-    "from allennlp.data.iterators import BasicIterator\n",
     "from allennlp.data.token_indexers import TokenIndexer, SingleIdTokenIndexer\n",
     "from allennlp.data.tokenizers import Token, CharacterTokenizer\n",
     "from allennlp.data.vocabulary import Vocabulary, DEFAULT_PADDING_TOKEN\n",
@@ -35,7 +37,7 @@
     "from allennlp.modules.text_field_embedders import TextFieldEmbedder, BasicTextFieldEmbedder\n",
     "from allennlp.modules.token_embedders import Embedding\n",
     "from allennlp.nn.util import get_text_field_mask, sequence_cross_entropy_with_logits\n",
-    "from allennlp.training.trainer import Trainer"
+    "from allennlp.training.trainer import GradientDescentTrainer"
    ]
   },
   {
@@ -120,6 +122,27 @@
     "        embeddings = self.embedder(input_tokens)\n",
     "        rnn_hidden = self.rnn(embeddings, mask)\n",
     "        out_logits = self.hidden2out(rnn_hidden)\n",
+    "\n",
+    "        \"\"\"\n",
+    "        THIS IS LIKELY NOT HOW I SHOULD FIX THIS BUT IT WAS THE BEST\n",
+    "        I COULD DO TO GET THIS WORKING\n",
+    "\n",
+    "        At this stage, `output_tokens` looks like this (module the specific token indices):\n",
+    "\n",
+    "        {'tokens': {'tokens': tensor([[16, 45,  5,  ...,  0,  0,  0],\n",
+    "                [51, 56, 48,  ...,  0,  0,  0],\n",
+    "                [44, 54,  2,  ...,  0,  0,  0],\n",
+    "                ...,\n",
+    "                [14, 54,  7,  ...,  0,  0,  0],\n",
+    "                [10, 48, 22,  ...,  0,  0,  0],\n",
+    "                [51, 36, 56,  ..., 58,  0,  0]])}}\n",
+    "\n",
+    "        which seems like it's being double indexed somehow.\n",
+    "\n",
+    "        Thus, calling output_tokens = output_tokens[\"tokens\"] to unnest `tokens`\n",
+    "        resolves this in an unideal way.\n",
+    "        \"\"\"\n",
+    "        output_tokens = output_tokens[\"tokens\"]\n",
     "        loss = sequence_cross_entropy_with_logits(out_logits, output_tokens['tokens'], mask)\n",
     "\n",
     "        return {'loss': loss}\n",
@@ -219,8 +242,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "iterator = BasicIterator(batch_size=BATCH_SIZE)\n",
-    "iterator.index_with(vocab)\n",
+    "dataset = AllennlpDataset(instances, vocab)\n",
+    "data_loader = DataLoader(dataset,\n",
+    "                         batch_size=BATCH_SIZE)\n",
     "\n",
     "optimizer = optim.Adam(model.parameters(), lr=5.e-3)"
    ]
@@ -231,11 +255,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trainer = Trainer(model=model,\n",
-    "                  optimizer=optimizer,\n",
-    "                  iterator=iterator,\n",
-    "                  train_dataset=instances,\n",
-    "                  num_epochs=10)\n",
+    "trainer = GradientDescentTrainer(\n",
+    "    model=model,\n",
+    "    optimizer=optimizer,\n",
+    "    data_loader=data_loader,\n",
+    "    num_epochs=10)\n",
+    "\n",
     "trainer.train()"
    ]
   },

--- a/examples/ner/ner.ipynb
+++ b/examples/ner/ner.ipynb
@@ -6,7 +6,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install allennlp\n",
+    "!pip install allennlp==1.0.0\n",
+    "!pip install allennlp-models==1.0.0\n",
     "!git clone https://github.com/mhagiwara/realworldnlp.git\n",
     "%cd realworldnlp"
    ]
@@ -24,10 +25,10 @@
     "import torch\n",
     "import torch.optim as optim\n",
     "from allennlp.common.file_utils import cached_path\n",
-    "from allennlp.data import DatasetReader\n",
+    "from allennlp.data import DataLoader\n",
     "from allennlp.data.fields import TextField, SequenceLabelField\n",
     "from allennlp.data.instance import Instance\n",
-    "from allennlp.data.iterators import BucketIterator\n",
+    "from allennlp.data.samplers import BucketBatchSampler\n",
     "from allennlp.data.token_indexers import TokenIndexer, SingleIdTokenIndexer\n",
     "from allennlp.data.tokenizers.token import Token\n",
     "from allennlp.data.vocabulary import Vocabulary\n",
@@ -37,7 +38,8 @@
     "from allennlp.modules.token_embedders import Embedding\n",
     "from allennlp.nn.util import get_text_field_mask, sequence_cross_entropy_with_logits\n",
     "from allennlp.training.metrics import CategoricalAccuracy, SpanBasedF1Measure\n",
-    "from allennlp.training.trainer import Trainer\n",
+    "from allennlp.training.trainer import GradientDescentTrainer\n",
+    "from allennlp.data.dataset_readers.dataset_reader import DatasetReader, AllennlpDataset\n",
     "from overrides import overrides"
    ]
   },
@@ -151,13 +153,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "reader = NERDatasetReader()\n",
-    "dataset = list(reader.read('https://s3.amazonaws.com/realworldnlpbook/data/entity-annotated-corpus/ner_dataset.csv'))"
+    "dataset = reader.read('https://s3.amazonaws.com/realworldnlpbook/data/entity-annotated-corpus/ner_dataset.csv')"
    ]
   },
   {
@@ -183,8 +183,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_dataset = [inst for i, inst in enumerate(dataset) if i % 10 != 0]\n",
-    "dev_dataset = [inst for i, inst in enumerate(dataset) if i % 10 == 0]"
+    "# Cast back to AllennlpDataset after splitting into train/dev\n",
+    "\n",
+    "train_dataset = AllennlpDataset([inst for i, inst in enumerate(dataset) if i % 10 != 0])\n",
+    "dev_dataset = AllennlpDataset([inst for i, inst in enumerate(dataset) if i % 10 == 0])"
    ]
   },
   {
@@ -232,6 +234,34 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "train_dataset.index_with(vocab)\n",
+    "dev_dataset.index_with(vocab)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_data_loader = DataLoader(train_dataset,\n",
+    "                         batch_sampler=BucketBatchSampler(\n",
+    "                             train_dataset,\n",
+    "                             batch_size=16,\n",
+    "                             sorting_keys=[\"tokens\"]))\n",
+    "dev_data_loader = DataLoader(dev_dataset,\n",
+    "                         batch_sampler=BucketBatchSampler(\n",
+    "                             dev_dataset,\n",
+    "                             batch_size=16,\n",
+    "                             sorting_keys=[\"tokens\"]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "optimizer = optim.Adam(model.parameters())"
    ]
   },
@@ -241,23 +271,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "iterator = BucketIterator(batch_size=16, sorting_keys=[(\"tokens\", \"num_tokens\")])\n",
-    "iterator.index_with(vocab)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "trainer = Trainer(model=model,\n",
-    "                  optimizer=optimizer,\n",
-    "                  iterator=iterator,\n",
-    "                  train_dataset=train_dataset,\n",
-    "                  validation_dataset=dev_dataset,\n",
-    "                  patience=10,\n",
-    "                  num_epochs=10)\n",
+    "trainer = GradientDescentTrainer(\n",
+    "    model=model,\n",
+    "    optimizer=optimizer,\n",
+    "    data_loader=train_data_loader,\n",
+    "    validation_data_loader=dev_data_loader,\n",
+    "    patience=10,\n",
+    "    num_epochs=20)\n",
+    "\n",
     "trainer.train()"
    ]
   },
@@ -271,13 +292,6 @@
     "labels = predict(tokens, model)\n",
     "print(' '.join('{}/{}'.format(token, label) for token, label in zip(tokens, labels)))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/pos/pos_tagger.ipynb
+++ b/examples/pos/pos_tagger.ipynb
@@ -6,7 +6,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install allennlp\n",
+    "!pip install allennlp==1.0.0\n",
+    "!pip install allennlp-models==1.0.0\n",
     "!git clone https://github.com/mhagiwara/realworldnlp.git\n",
     "%cd realworldnlp"
    ]
@@ -22,8 +23,13 @@
     "import numpy as np\n",
     "import torch\n",
     "import torch.optim as optim\n",
-    "from allennlp.data.dataset_readers import UniversalDependenciesDatasetReader\n",
-    "from allennlp.data.iterators import BucketIterator\n",
+    "\n",
+    "# from allennlp.data.dataset_readers import UniversalDependenciesDatasetReader\n",
+    "from allennlp_models.structured_prediction.dataset_readers.universal_dependencies import UniversalDependenciesDatasetReader\n",
+    "# from allennlp.data.iterators import BucketIterator\n",
+    "from allennlp.data import DataLoader\n",
+    "from allennlp.data.samplers import BucketBatchSampler\n",
+    "\n",
     "from allennlp.data.vocabulary import Vocabulary\n",
     "from allennlp.models import Model\n",
     "from allennlp.modules.seq2seq_encoders import Seq2SeqEncoder, PytorchSeq2SeqWrapper\n",
@@ -31,7 +37,8 @@
     "from allennlp.modules.token_embedders import Embedding\n",
     "from allennlp.nn.util import get_text_field_mask, sequence_cross_entropy_with_logits\n",
     "from allennlp.training.metrics import CategoricalAccuracy\n",
-    "from allennlp.training.trainer import Trainer\n",
+    "# from allennlp.training.trainer import Trainer\n",
+    "from allennlp.training.trainer import GradientDescentTrainer\n",
     "\n",
     "from realworldnlp.predictors import UniversalPOSPredictor"
    ]
@@ -119,6 +126,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "train_dataset.index_with(vocab)\n",
+    "dev_dataset.index_with(vocab)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "token_embedding = Embedding(num_embeddings=vocab.get_vocab_size('tokens'),\n",
     "                            embedding_dim=EMBEDDING_SIZE)\n",
     "word_embeddings = BasicTextFieldEmbedder({\"tokens\": token_embedding})"
@@ -158,7 +175,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "iterator = BucketIterator(batch_size=16, sorting_keys=[(\"words\", \"num_tokens\")])"
+    "# iterator = BucketIterator(batch_size=16, sorting_keys=[(\"words\", \"num_tokens\")])\n",
+    "train_data_loader = DataLoader(\n",
+    "    train_dataset,\n",
+    "    batch_sampler=BucketBatchSampler(\n",
+    "        train_dataset,\n",
+    "        batch_size=32,\n",
+    "        sorting_keys=[\"words\"]\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "dev_data_loader = DataLoader(\n",
+    "    train_dataset,\n",
+    "    batch_sampler=BucketBatchSampler(\n",
+    "        dev_dataset,\n",
+    "        batch_size=32,\n",
+    "        sorting_keys=[\"words\"]\n",
+    "    )\n",
+    ")"
    ]
   },
   {
@@ -167,7 +201,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "iterator.index_with(vocab)"
+    "# iterator.index_with(vocab)"
    ]
   },
   {
@@ -176,13 +210,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trainer = Trainer(model=model,\n",
-    "                  optimizer=optimizer,\n",
-    "                  iterator=iterator,\n",
-    "                  train_dataset=train_dataset,\n",
-    "                  validation_dataset=dev_dataset,\n",
-    "                   patience=10,\n",
-    "                   num_epochs=10)\n",
+    "trainer = GradientDescentTrainer(\n",
+    "    model=model,\n",
+    "    optimizer=optimizer,\n",
+    "    data_loader=train_data_loader,\n",
+    "    validation_data_loader=dev_data_loader,\n",
+    "    patience=10,\n",
+    "    num_epochs=10)\n",
     "trainer.train()"
    ]
   },
@@ -199,34 +233,14 @@
     "\n",
     "[vocab.get_token_from_index(tag_id, 'pos') for tag_id in tag_ids]"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/pos/pos_tagger.ipynb
+++ b/examples/pos/pos_tagger.ipynb
@@ -24,12 +24,9 @@
     "import torch\n",
     "import torch.optim as optim\n",
     "\n",
-    "# from allennlp.data.dataset_readers import UniversalDependenciesDatasetReader\n",
-    "from allennlp_models.structured_prediction.dataset_readers.universal_dependencies import UniversalDependenciesDatasetReader\n",
-    "# from allennlp.data.iterators import BucketIterator\n",
+    "\n",
     "from allennlp.data import DataLoader\n",
     "from allennlp.data.samplers import BucketBatchSampler\n",
-    "\n",
     "from allennlp.data.vocabulary import Vocabulary\n",
     "from allennlp.models import Model\n",
     "from allennlp.modules.seq2seq_encoders import Seq2SeqEncoder, PytorchSeq2SeqWrapper\n",
@@ -37,8 +34,8 @@
     "from allennlp.modules.token_embedders import Embedding\n",
     "from allennlp.nn.util import get_text_field_mask, sequence_cross_entropy_with_logits\n",
     "from allennlp.training.metrics import CategoricalAccuracy\n",
-    "# from allennlp.training.trainer import Trainer\n",
     "from allennlp.training.trainer import GradientDescentTrainer\n",
+    "from allennlp_models.structured_prediction.dataset_readers.universal_dependencies import UniversalDependenciesDatasetReader\n",
     "\n",
     "from realworldnlp.predictors import UniversalPOSPredictor"
    ]

--- a/examples/sentiment/sst_cnn_classifier.ipynb
+++ b/examples/sentiment/sst_cnn_classifier.ipynb
@@ -6,7 +6,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install allennlp\n",
+    "!pip install allennlp==1.0.0\n",
+    "!pip install allennlp_models==1.0.0\n",
     "!git clone https://github.com/mhagiwara/realworldnlp.git\n",
     "%cd realworldnlp"
    ]
@@ -22,9 +23,9 @@
     "import numpy as np\n",
     "import torch\n",
     "import torch.optim as optim\n",
-    "from allennlp.data.dataset_readers.stanford_sentiment_tree_bank import \\\n",
-    "    StanfordSentimentTreeBankDatasetReader\n",
-    "from allennlp.data.iterators import BucketIterator\n",
+    "\n",
+    "from allennlp.data import DataLoader\n",
+    "from allennlp.data.samplers import BucketBatchSampler\n",
     "from allennlp.data.token_indexers import SingleIdTokenIndexer\n",
     "from allennlp.data.vocabulary import Vocabulary\n",
     "from allennlp.models import Model\n",
@@ -33,7 +34,9 @@
     "from allennlp.modules.token_embedders import Embedding\n",
     "from allennlp.nn.util import get_text_field_mask\n",
     "from allennlp.training.metrics import CategoricalAccuracy, F1Measure\n",
-    "from allennlp.training.trainer import Trainer\n",
+    "from allennlp.training.trainer import GradientDescentTrainer\n",
+    "from allennlp_models.classification.dataset_readers.stanford_sentiment_tree_bank import \\\n",
+    "    StanfordSentimentTreeBankDatasetReader\n",
     "\n",
     "from realworldnlp.predictors import SentenceClassifierPredictor"
    ]
@@ -51,9 +54,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "@Model.register(\"cnn_classifier\")\n",
@@ -178,7 +179,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "iterator = BucketIterator(batch_size=32, sorting_keys=[(\"tokens\", \"num_tokens\")])"
+    "train_dataset.index_with(vocab)\n",
+    "dev_dataset.index_with(vocab)"
    ]
   },
   {
@@ -187,7 +189,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "iterator.index_with(vocab)"
+    "train_data_loader = DataLoader(train_dataset,\n",
+    "                         batch_sampler=BucketBatchSampler(\n",
+    "                             train_dataset,\n",
+    "                             batch_size=32,\n",
+    "                             sorting_keys=[\"tokens\"]))\n",
+    "dev_data_loader = DataLoader(dev_dataset,\n",
+    "                         batch_sampler=BucketBatchSampler(\n",
+    "                             dev_dataset,\n",
+    "                             batch_size=32,\n",
+    "                             sorting_keys=[\"tokens\"]))"
    ]
   },
   {
@@ -205,13 +216,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trainer = Trainer(model=model,\n",
-    "                  optimizer=optimizer,\n",
-    "                  iterator=iterator,\n",
-    "                  train_dataset=train_dataset,\n",
-    "                  validation_dataset=dev_dataset,\n",
-    "                  patience=10,\n",
-    "                  num_epochs=20)\n",
+    "trainer = GradientDescentTrainer(\n",
+    "    model=model,\n",
+    "    optimizer=optimizer,\n",
+    "    data_loader=train_data_loader,\n",
+    "    validation_data_loader=dev_data_loader,\n",
+    "    patience=10,\n",
+    "    num_epochs=20)\n",
+    "\n",
     "trainer.train()"
    ]
   },


### PR DESCRIPTION
Contains a few fixes to update notebooks to AllenNLP 1.0.0.

Mostly, updates some of the data loaders to properly import from the new
allennlp-models package as well as fix up their instantiation and use.

* [POS notebook output]
* [LM notebook output]
* [NER notebook output]
* [CNN notebook output]

[POS notebook output]: https://www.dropbox.com/s/svt2vsbwxr1m5if/pos_tagger.html?dl=0
[LM notebook output]: https://www.dropbox.com/s/6uu3g9v82475u67/lm.html?dl=0
[NER notebook output]: https://www.dropbox.com/s/n7kdvt652yceb43/ner.html?dl=0
[CNN notebook output]: https://www.dropbox.com/s/zir11ne7vbg7ark/sst_cnn_classifier.html?dl=0

---

I thought it might be helpful to update some of these to use AllenNLP >= 1.0.0. For most of them, I followed the example set in the updated sentiment notebook. I ran into a bit of trouble with the LM notebook where there the output data point seemed to be "wrapped" twice, nested as `{"tokens": {"tokens": <vector>...`

I figured I'd make a PR to help aid the process of transforming these. I'm also happy to close this if it's redundant. 